### PR TITLE
Ramrecorder

### DIFF
--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -856,6 +856,13 @@ void exception_handler(int sig)
   // will trigger the log files to be copied to the diags bundle
   LOG_COMMIT();
 
+  // Dump out the RAM trace buffer
+  char ramname[64];
+  sprintf(ramname, "/var/log/sprout/ramtrace.%ld.txt", time(NULL));
+  FILE *ramtrace = fopen(ramname, "w");
+  Log::ramDecode(ramtrace);
+  fclose(ramtrace);
+
   // Dump a core.
   abort();
 }

--- a/sprout/stack.cpp
+++ b/sprout/stack.cpp
@@ -518,6 +518,7 @@ static void pjsip_log_handler(int level,
   default: level = 5; break;
   }
 
+  TRC_RAMTRACE("%s", data);
   Log::write(level, "pjsip", 0, data);
 }
 


### PR DESCRIPTION
This integration with the "RAM recorder" logic in cpp-common also traces PJSIP trace calls and dumps the trace buffer from the sprout exception handler