### PR TITLE
/ect/clearwater/enum.json isn't reloaded on a SIGHUP 

### DIFF
--- a/include/bgcfservice.h
+++ b/include/bgcfservice.h
@@ -43,7 +43,7 @@
 #include <map>
 #include <string>
 #include <boost/regex.hpp>
-
+#include <boost/thread.hpp>
 #include <functional>
 #include "updater.h"
 #include "sas.h"
@@ -57,9 +57,9 @@ public:
   /// Updates the bgcf routes
   void update_routes();
 
-  std::vector<std::string> get_route_from_domain(const std::string &domain, 
+  std::vector<std::string> get_route_from_domain(const std::string &domain,
                                                  SAS::TrailId trail) const;
-  std::vector<std::string> get_route_from_number(const std::string &number, 
+  std::vector<std::string> get_route_from_number(const std::string &number,
                                                  SAS::TrailId trail) const;
 
 private:
@@ -68,6 +68,9 @@ private:
   std::string _configuration;
   Updater<void, BgcfService>* _updater;
 
+  // Mark as mutable to flag that this can be modified without affecting the
+  // external behaviour of the class, allowing for locking in 'const' methods.
+  mutable boost::shared_mutex _routes_rw_lock;
 };
 
 #endif

--- a/include/enumservice.h
+++ b/include/enumservice.h
@@ -45,10 +45,12 @@
 #include <boost/regex.hpp>
 #include <netinet/in.h>
 #include <ares.h>
+#include <pthread.h>
 #include "sas.h"
 #include "baseresolver.h"
 #include "dnsresolver.h"
 #include "communicationmonitor.h"
+#include "updater.h"
 
 /// @class EnumService
 ///
@@ -88,9 +90,14 @@ public:
   JSONEnumService(std::string configuration = "./enum.json");
   ~JSONEnumService();
 
+  // Updates the enum configuration
+  void update_enum();
+
   std::string lookup_uri_from_user(const std::string& user, SAS::TrailId trail) const;
 
 private:
+  void destroy_prefixes();
+
   struct NumberPrefix
   {
     std::string prefix;
@@ -100,8 +107,10 @@ private:
 
   std::list<struct NumberPrefix*> _number_prefixes;
 
+  std::string _configuration;
   NumberPrefix* prefix_match(const std::string& number) const;
-
+  Updater<void, JSONEnumService>* _updater;
+  mutable pthread_mutex_t _number_prefixes_rw_lock;
 };
 
 /// @class DNSEnumService

--- a/include/enumservice.h
+++ b/include/enumservice.h
@@ -43,9 +43,9 @@
 #include <list>
 #include <string>
 #include <boost/regex.hpp>
+#include <boost/thread.hpp>
 #include <netinet/in.h>
 #include <ares.h>
-#include <pthread.h>
 #include "sas.h"
 #include "baseresolver.h"
 #include "dnsresolver.h"
@@ -96,8 +96,6 @@ public:
   std::string lookup_uri_from_user(const std::string& user, SAS::TrailId trail) const;
 
 private:
-  void destroy_prefixes();
-
   struct NumberPrefix
   {
     std::string prefix;
@@ -105,12 +103,15 @@ private:
     std::string replace;
   };
 
-  std::list<struct NumberPrefix*> _number_prefixes;
+  const NumberPrefix* prefix_match(const std::string& number) const;
 
   std::string _configuration;
-  NumberPrefix* prefix_match(const std::string& number) const;
+  std::vector<NumberPrefix> _number_prefixes;
   Updater<void, JSONEnumService>* _updater;
-  mutable pthread_mutex_t _number_prefixes_rw_lock;
+
+  // Mark as mutable to flag that this can be modified without affecting the
+  // external behaviour of the class, allowing for locking in 'const' methods.
+  mutable boost::shared_mutex _number_prefixes_rw_lock;
 };
 
 /// @class DNSEnumService

--- a/include/scscfselector.h
+++ b/include/scscfselector.h
@@ -41,6 +41,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include <boost/thread.hpp>
 #include "updater.h"
 #include "sas.h"
 
@@ -70,6 +71,7 @@ private:
   std::string _configuration;
   std::vector<scscf> _scscfs;
   Updater<void, SCSCFSelector>* _updater;
+  boost::shared_mutex _scscfs_rw_lock;
 };
 
 #endif

--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -93,8 +93,6 @@ JSONEnumService::JSONEnumService(std::string configuration):
   _configuration(configuration),
   _updater(NULL)
 {
-  pthread_mutex_init(&_number_prefixes_rw_lock, NULL);
-
   // create and updater which, by default, runs the function when initialized
   _updater = new Updater<void, JSONEnumService>(this,
                                   std::mem_fun(&JSONEnumService::update_enum));
@@ -142,7 +140,7 @@ void JSONEnumService::update_enum()
 
   try
   {
-    std::list<struct NumberPrefix*> new_number_prefixes;
+    std::vector<NumberPrefix> new_number_prefixes;
 
     JSON_ASSERT_CONTAINS(doc, "number_blocks");
     JSON_ASSERT_ARRAY(doc["number_blocks"]);
@@ -161,20 +159,19 @@ void JSONEnumService::update_enum()
 
         // Entry is well-formed, so add it.
         LOG_DEBUG("Found valid number prefix block %s", prefix.c_str());
-        NumberPrefix *pfix = new NumberPrefix;
-        pfix->prefix = prefix;
+        NumberPrefix pfix;
+        pfix.prefix = prefix;
 
-        if (parse_regex_replace(regex, pfix->match, pfix->replace))
+        if (parse_regex_replace(regex, pfix.match, pfix.replace))
         {
           new_number_prefixes.push_back(pfix);
           LOG_STATUS("  Adding number prefix %s, regex=%s",
-                     pfix->prefix.c_str(), regex.c_str());
+                     pfix.prefix.c_str(), regex.c_str());
         }
         else
         {
           LOG_WARNING("Badly formed regular expression in ENUM number block %s",
                       regex.c_str());
-          delete pfix;
         }
       }
       catch (JsonFormatError err)
@@ -185,11 +182,9 @@ void JSONEnumService::update_enum()
       }
     }
 
-    // Delete the old prefixes and store the new ones under mutex protection.
-    pthread_mutex_lock(&_number_prefixes_rw_lock);
-    destroy_prefixes();
+    // Take a write lock on the mutex in RAII style
+    boost::lock_guard<boost::shared_mutex> write_lock(_number_prefixes_rw_lock);
     _number_prefixes = new_number_prefixes;
-    pthread_mutex_unlock(&_number_prefixes_rw_lock);
   }
   catch (JsonFormatError err)
   {
@@ -197,26 +192,10 @@ void JSONEnumService::update_enum()
   }
 }
 
-void JSONEnumService::destroy_prefixes()
-{
-  for (std::list<struct NumberPrefix*>::iterator it = _number_prefixes.begin();
-       it != _number_prefixes.end();
-       it++)
-  {
-    delete *it;
-  }
-}
-
 JSONEnumService::~JSONEnumService()
 {
   delete _updater;
   _updater = NULL;
-
-  // Lock not required here as nothing should be using the object when it is
-  // destroyed.
-  destroy_prefixes();
-
-  pthread_mutex_destroy(&_number_prefixes_rw_lock);
 }
 
 
@@ -233,7 +212,11 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
   }
 
   std::string aus = user_to_aus(user);
-  struct NumberPrefix* pfix = prefix_match(aus);
+
+  // Take a read lock on the mutex in RAII style
+  boost::shared_lock<boost::shared_mutex> read_lock(_number_prefixes_rw_lock);
+
+  const struct NumberPrefix* pfix = prefix_match(aus);
 
   if (pfix == NULL)
   {
@@ -260,37 +243,32 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 }
 
 
-JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
+const JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
 {
-  JSONEnumService::NumberPrefix* xoPrefix = NULL;
-
-  pthread_mutex_lock(&_number_prefixes_rw_lock);
+  const JSONEnumService::NumberPrefix* matching_prefix = NULL;
 
   // For simplicity this uses a linear scan since we don't expect too many
   // entries.  Should shift to a radix tree at some point.
-  for (std::list<struct NumberPrefix*>::const_iterator it = _number_prefixes.begin();
+  for (std::vector<NumberPrefix>::const_iterator it = _number_prefixes.begin();
        it != _number_prefixes.end();
        it++)
   {
-    int len = std::min(number.size(), (*it)->prefix.size());
+    int len = std::min(number.size(), it->prefix.size());
 
     LOG_DEBUG("Comparing first %d numbers of %s against prefix %s",
-              len, number.c_str(), (*it)->prefix.c_str());
+              len, number.c_str(), it->prefix.c_str());
 
-    if (number.compare(0, len, (*it)->prefix, 0, len) == 0)
+    if (number.compare(0, len, it->prefix, 0, len) == 0)
     {
       // Found a match, so return it (at the moment we assume the entries are
       // ordered with most specific matches first so we can stop as soon as we
       // have one match).
       LOG_DEBUG("Match found");
-      xoPrefix = *it;
-      break;
+      return &*it;
     }
   }
 
-  pthread_mutex_unlock(&_number_prefixes_rw_lock);
-
-  return xoPrefix;
+  return NULL;
 }
 
 DNSEnumService::DNSEnumService(const std::vector<std::string>& dns_servers,

--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -209,13 +209,14 @@ void JSONEnumService::destroy_prefixes()
 
 JSONEnumService::~JSONEnumService()
 {
-  // Destroy the updater
   delete _updater;
   _updater = NULL;
 
   // Lock not required here as nothing should be using the object when it is
   // destroyed.
   destroy_prefixes();
+
+  pthread_mutex_destroy(&_number_prefixes_rw_lock);
 }
 
 
@@ -261,9 +262,9 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 
 JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
 {
-  pthread_mutex_lock(&_number_prefixes_rw_lock);
-
   JSONEnumService::NumberPrefix* xoPrefix = NULL;
+
+  pthread_mutex_lock(&_number_prefixes_rw_lock);
 
   // For simplicity this uses a linear scan since we don't expect too many
   // entries.  Should shift to a radix tree at some point.

--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -243,6 +243,10 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 }
 
 
+// This function returns a pointer to a struct that may be destroyed by the
+// updater. Callers must therefore ensure that they have the read lock before
+// calling this function and only release the lock once they no longer need
+// the object.
 const JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
 {
   const JSONEnumService::NumberPrefix* matching_prefix = NULL;

--- a/sprout/scscfselector.cpp
+++ b/sprout/scscfselector.cpp
@@ -109,18 +109,18 @@ void SCSCFSelector::update_scscf()
          scscfs_it != scscfs_arr.End();
          ++scscfs_it)
     {
-      try 
+      try
       {
         scscf_t new_scscf;
         JSON_GET_STRING_MEMBER(*scscfs_it, "server", new_scscf.server);
         JSON_GET_INT_MEMBER(*scscfs_it, "priority", new_scscf.priority);
         JSON_GET_INT_MEMBER(*scscfs_it, "weight", new_scscf.weight);
-        
+
         JSON_ASSERT_CONTAINS(*scscfs_it, "capabilities");
         JSON_ASSERT_ARRAY((*scscfs_it)["capabilities"]);
         const rapidjson::Value& cap_arr = (*scscfs_it)["capabilities"];
         std::vector<int> capabilities_vec;
- 
+
         for (rapidjson::Value::ConstValueIterator cap_it = cap_arr.Begin();
              cap_it != cap_arr.End();
              ++cap_it)
@@ -130,7 +130,7 @@ void SCSCFSelector::update_scscf()
 
         // Sort the capabilities and remove duplicates
         std::sort(capabilities_vec.begin(), capabilities_vec.end());
-        capabilities_vec.erase(unique(capabilities_vec.begin(),  
+        capabilities_vec.erase(unique(capabilities_vec.begin(),
                                       capabilities_vec.end()),
                                capabilities_vec.end() );
         new_scscf.capabilities = capabilities_vec;
@@ -145,6 +145,8 @@ void SCSCFSelector::update_scscf()
       }
     }
 
+    // Take a write lock on the mutex in RAII style
+    boost::lock_guard<boost::shared_mutex> write_lock(_scscfs_rw_lock);
     _scscfs = new_scscfs;
   }
   catch (JsonFormatError err)
@@ -165,6 +167,11 @@ std::string SCSCFSelector::get_scscf(const std::vector<int> &mandatory,
                                      const std::vector<std::string> &rejects,
                                      SAS::TrailId trail)
 {
+  // Take a read lock on the mutex in RAII style. See
+  // http://www.boost.org/doc/libs/1_41_0/doc/html/thread/synchronization.html
+  // for documentation.
+  boost::shared_lock<boost::shared_mutex> read_lock(_scscfs_rw_lock);
+
   // There are no configured S-CSCFs.
   if (_scscfs.empty())
   {


### PR DESCRIPTION
Fix details: Added Updater to enumservice to bring it in line with other json file handler classes.

Test details: Ran sprout reload after modifying enum.json and checked logs to ensure that new config was read. Also ran with broken config to check that sprout didn't crash or some other error. Both cases worked as expected. New config was picked up and bad config resulted in an error log 