### PR TITLE
[Reviewer: Steve] Don't route subscribes to S-CSCF via sproutlet interface

### DIFF
--- a/mk/sprout.mk
+++ b/mk/sprout.mk
@@ -17,6 +17,9 @@ sprout: pjsip libmemcached
 sprout_test:
 	${MAKE} -C ${SPROUT_DIR} test
 
+sprout_runtest:
+	${MAKE} -C ${SPROUT_DIR} run_test
+
 sprout_clean:
 	${MAKE} -C ${SPROUT_DIR} clean
 	-${MAKE} -C ${SPROUT_TEST_DIR} clean

--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -163,7 +163,7 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
   // authentication module is invoked between the I-CSCF and the S-CSCF
   if (sproutlet && (sproutlet->service_name() == "scscf"))
   {
-    TRC_DEBUG("Ignore SCSCF service");
+    TRC_DEBUG("Only route to SCSCF by port");
     sproutlet = NULL;
   }
 

--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -163,6 +163,7 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
   // authentication module is invoked between the I-CSCF and the S-CSCF
   if (sproutlet && (sproutlet->service_name() == "scscf"))
   {
+    TRC_DEBUG("Ignore SCSCF service");
     sproutlet = NULL;
   }
 
@@ -192,6 +193,18 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
     }
   }
 
+  if (sproutlet && 
+      (sproutlet->service_name() == "scscf") &&
+      pjsip_method_cmp(&req->line.req.method, 
+                       pjsip_get_subscribe_method()) == 0)
+  {
+    // This is a subscribe being routed back to the S-CSCF sproutlet but to 
+    // get this handled correctly we need route it externally to make sure it 
+    // hits the subscription module.
+    TRC_DEBUG("Don't route S-CSCF subscribe message via sproutlet");
+    sproutlet = NULL;
+  }
+  
   return sproutlet;
 }
 

--- a/sprout/ut/sproutletproxy_test.cpp
+++ b/sprout/ut/sproutletproxy_test.cpp
@@ -29,7 +29,7 @@
  * propagate, and distribute a work formed by combining OpenSSL with The
  * Software, or a work derivative of such a combination, even if such
  * copying, modification, propagation, or distribution would otherwise
- * violate the terms of the GPL. Y must comply with the GPL in all
+ * violate the terms of the GPL. You must comply with the GPL in all
  * respects for all of the code used other than OpenSSL.
  * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
  * Project and licensed under the OpenSSL Licenses, or a work based on such

--- a/sprout/ut/sproutletproxy_test.cpp
+++ b/sprout/ut/sproutletproxy_test.cpp
@@ -43,6 +43,11 @@
 #include "siptest.hpp"
 #include "test_interposer.hpp"
 #include "sproutletproxy.h"
+#include "pjutils.h"
+#include "pjsip.h"
+#include "pjsip_simple.h"
+
+#include <mutex>
 
 using namespace std;
 using testing::InSequence;
@@ -463,6 +468,22 @@ private:
   pjsip_method_e _method;
 };
 
+class FakeSproutletTsxDummySCSCF : public SproutletTsx
+{
+public:
+  FakeSproutletTsxDummySCSCF(SproutletTsxHelper* helper) :
+    SproutletTsx(helper)
+  {
+  }
+
+  void on_rx_initial_request(pjsip_msg* req)
+  {
+    // We shouldn't get passed any subscribe messages
+    ASSERT_NE(pj_stricmp2(&req->line.req.method.name, "SUBSCRIBE"), 0);
+    send_request(req);
+  }
+};
+
 class SproutletProxyTest : public SipTest
 {
 public:
@@ -492,6 +513,7 @@ public:
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxDelayRedirect<1> >("delayredirect", 0, ""));
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxBad >("bad", 0, ""));
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxB2BUA >("b2bua", 0, ""));
+    _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxDummySCSCF>("scscf", 44444, "scscf"));
 
     // Create a host alias.
     std::unordered_set<std::string> host_aliases;
@@ -1951,4 +1973,49 @@ TEST_F(SproutletProxyTest, LoopDetection)
 
   delete tp;
 }
+
+TEST_F(SproutletProxyTest, LocalSubscription)
+{
+  // Tests standard routing of a local subscription request to ensure it is
+  // not routed via the sproutlet interface.
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        44444,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Inject a request with a Route header not referencing this node or the
+  // home domain.
+  Message msg1;
+  msg1._method = "SUBSCRIBE";
+  msg1._requri = "sip:bob@homedomain";
+  msg1._from = "sip:alice@homedomain";
+  msg1._to = "sip:bob@homedomain";
+  msg1._via = tp->to_string(false);
+  msg1._route = "Route: <sip:scscf@proxy1.homedomain;transport=TCP;lr>\r\nRoute: <sip:proxy1.awaydomain;transport=TCP;lr>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting the forwarded SUBSCRIBE
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  expect_target("TCP", "10.10.20.1", 5060, tdata);
+  ReqMatcher("SUBSCRIBE").matches(tdata->msg);
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_current_txdata(200));
+
+  // Check the 200 OK.
+  tdata = current_txdata();
+  RespMatcher(200).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // All done!
+  ASSERT_EQ(0, txdata_count());
+
+  delete tp;
+}
+
 

--- a/sprout/ut/sproutletproxy_test.cpp
+++ b/sprout/ut/sproutletproxy_test.cpp
@@ -29,7 +29,7 @@
  * propagate, and distribute a work formed by combining OpenSSL with The
  * Software, or a work derivative of such a combination, even if such
  * copying, modification, propagation, or distribution would otherwise
- * violate the terms of the GPL. You must comply with the GPL in all
+ * violate the terms of the GPL. Y must comply with the GPL in all
  * respects for all of the code used other than OpenSSL.
  * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
  * Project and licensed under the OpenSSL Licenses, or a work based on such
@@ -480,7 +480,9 @@ public:
   {
     // We shouldn't get passed any subscribe messages
     ASSERT_NE(pj_stricmp2(&req->line.req.method.name, "SUBSCRIBE"), 0);
-    send_request(req);
+    pjsip_msg* rsp = create_response(req, PJSIP_SC_NOT_FOUND);
+    free_msg(req);
+    send_response(rsp);
   }
 };
 
@@ -2009,6 +2011,51 @@ TEST_F(SproutletProxyTest, LocalSubscription)
   // Check the 200 OK.
   tdata = current_txdata();
   RespMatcher(200).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // All done!
+  ASSERT_EQ(0, txdata_count());
+
+  delete tp;
+}
+
+TEST_F(SproutletProxyTest, LocalNonSubscribe)
+{
+  // Tests standard routing of a local subscription request to ensure it is
+  // not routed via the sproutlet interface.
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        44444,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Inject a request with a Route header not referencing this node or the
+  // home domain.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:bob@homedomain";
+  msg1._from = "sip:alice@homedomain";
+  msg1._to = "sip:bob@homedomain";
+  msg1._via = tp->to_string(false);
+  msg1._route = "Route: <sip:scscf@proxy1.homedomain;transport=TCP;lr>\r\nRoute: <sip:proxy1.awaydomain;transport=TCP;lr>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting the forwarded SUBSCRIBE
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  EXPECT_EQ("To: <sip:bob@homedomain>", get_headers(tdata->msg, "To")); // No tag
+  free_txdata();
+
+  // Check the 486 Loop Detected.
+  tdata = current_txdata();
+  RespMatcher(404).matches(tdata->msg);
   tp->expect_target(tdata);
   free_txdata();
 


### PR DESCRIPTION
Code changes duplicates a test already used to make sure the authentication module is invoked.

Tested in UTs, making sure the PC live tests still work and testing that it fixes the bug with SUBSCRIBEs from Perimeta being responded to correctly instead of routed back to the clients.