### PR TITLE
Revert "Don't route subscribes to S-CSCF via sproutlet interface"

### DIFF
--- a/mk/sprout.mk
+++ b/mk/sprout.mk
@@ -17,9 +17,6 @@ sprout: pjsip libmemcached
 sprout_test:
 	${MAKE} -C ${SPROUT_DIR} test
 
-sprout_runtest:
-	${MAKE} -C ${SPROUT_DIR} run_test
-
 sprout_clean:
 	${MAKE} -C ${SPROUT_DIR} clean
 	-${MAKE} -C ${SPROUT_TEST_DIR} clean

--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -163,7 +163,6 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
   // authentication module is invoked between the I-CSCF and the S-CSCF
   if (sproutlet && (sproutlet->service_name() == "scscf"))
   {
-    TRC_DEBUG("Only route to SCSCF by port");
     sproutlet = NULL;
   }
 
@@ -193,18 +192,6 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
     }
   }
 
-  if (sproutlet && 
-      (sproutlet->service_name() == "scscf") &&
-      pjsip_method_cmp(&req->line.req.method, 
-                       pjsip_get_subscribe_method()) == 0)
-  {
-    // This is a subscribe being routed back to the S-CSCF sproutlet but to 
-    // get this handled correctly we need route it externally to make sure it 
-    // hits the subscription module.
-    TRC_DEBUG("Don't route S-CSCF subscribe message via sproutlet");
-    sproutlet = NULL;
-  }
-  
   return sproutlet;
 }
 

--- a/sprout/ut/sproutletproxy_test.cpp
+++ b/sprout/ut/sproutletproxy_test.cpp
@@ -43,11 +43,6 @@
 #include "siptest.hpp"
 #include "test_interposer.hpp"
 #include "sproutletproxy.h"
-#include "pjutils.h"
-#include "pjsip.h"
-#include "pjsip_simple.h"
-
-#include <mutex>
 
 using namespace std;
 using testing::InSequence;
@@ -468,24 +463,6 @@ private:
   pjsip_method_e _method;
 };
 
-class FakeSproutletTsxDummySCSCF : public SproutletTsx
-{
-public:
-  FakeSproutletTsxDummySCSCF(SproutletTsxHelper* helper) :
-    SproutletTsx(helper)
-  {
-  }
-
-  void on_rx_initial_request(pjsip_msg* req)
-  {
-    // We shouldn't get passed any subscribe messages
-    ASSERT_NE(pj_stricmp2(&req->line.req.method.name, "SUBSCRIBE"), 0);
-    pjsip_msg* rsp = create_response(req, PJSIP_SC_NOT_FOUND);
-    free_msg(req);
-    send_response(rsp);
-  }
-};
-
 class SproutletProxyTest : public SipTest
 {
 public:
@@ -515,7 +492,6 @@ public:
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxDelayRedirect<1> >("delayredirect", 0, ""));
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxBad >("bad", 0, ""));
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxB2BUA >("b2bua", 0, ""));
-    _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxDummySCSCF>("scscf", 44444, "scscf"));
 
     // Create a host alias.
     std::unordered_set<std::string> host_aliases;
@@ -1975,94 +1951,4 @@ TEST_F(SproutletProxyTest, LoopDetection)
 
   delete tp;
 }
-
-TEST_F(SproutletProxyTest, LocalSubscription)
-{
-  // Tests standard routing of a local subscription request to ensure it is
-  // not routed via the sproutlet interface.
-  pjsip_tx_data* tdata;
-
-  // Create a TCP connection to the listening port.
-  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
-                                        44444,
-                                        "1.2.3.4",
-                                        49152);
-
-  // Inject a request with a Route header not referencing this node or the
-  // home domain.
-  Message msg1;
-  msg1._method = "SUBSCRIBE";
-  msg1._requri = "sip:bob@homedomain";
-  msg1._from = "sip:alice@homedomain";
-  msg1._to = "sip:bob@homedomain";
-  msg1._via = tp->to_string(false);
-  msg1._route = "Route: <sip:scscf@proxy1.homedomain;transport=TCP;lr>\r\nRoute: <sip:proxy1.awaydomain;transport=TCP;lr>";
-  inject_msg(msg1.get_request(), tp);
-
-  // Expecting the forwarded SUBSCRIBE
-  ASSERT_EQ(1, txdata_count());
-  tdata = current_txdata();
-  expect_target("TCP", "10.10.20.1", 5060, tdata);
-  ReqMatcher("SUBSCRIBE").matches(tdata->msg);
-
-  // Send a 200 OK response.
-  inject_msg(respond_to_current_txdata(200));
-
-  // Check the 200 OK.
-  tdata = current_txdata();
-  RespMatcher(200).matches(tdata->msg);
-  tp->expect_target(tdata);
-  free_txdata();
-
-  // All done!
-  ASSERT_EQ(0, txdata_count());
-
-  delete tp;
-}
-
-TEST_F(SproutletProxyTest, LocalNonSubscribe)
-{
-  // Tests standard routing of a local subscription request to ensure it is
-  // not routed via the sproutlet interface.
-  pjsip_tx_data* tdata;
-
-  // Create a TCP connection to the listening port.
-  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
-                                        44444,
-                                        "1.2.3.4",
-                                        49152);
-
-  // Inject a request with a Route header not referencing this node or the
-  // home domain.
-  Message msg1;
-  msg1._method = "INVITE";
-  msg1._requri = "sip:bob@homedomain";
-  msg1._from = "sip:alice@homedomain";
-  msg1._to = "sip:bob@homedomain";
-  msg1._via = tp->to_string(false);
-  msg1._route = "Route: <sip:scscf@proxy1.homedomain;transport=TCP;lr>\r\nRoute: <sip:proxy1.awaydomain;transport=TCP;lr>";
-  inject_msg(msg1.get_request(), tp);
-
-  // Expecting the forwarded SUBSCRIBE
-  ASSERT_EQ(2, txdata_count());
-
-  // Check the 100 Trying.
-  tdata = current_txdata();
-  RespMatcher(100).matches(tdata->msg);
-  tp->expect_target(tdata);
-  EXPECT_EQ("To: <sip:bob@homedomain>", get_headers(tdata->msg, "To")); // No tag
-  free_txdata();
-
-  // Check the 486 Loop Detected.
-  tdata = current_txdata();
-  RespMatcher(404).matches(tdata->msg);
-  tp->expect_target(tdata);
-  free_txdata();
-
-  // All done!
-  ASSERT_EQ(0, txdata_count());
-
-  delete tp;
-}
-
 


### PR DESCRIPTION
Reverts ClearwaterCore/sprout#44

Full fix backmerged from PC relies on too many other changes.  SFR fixed in CCv9 instead.