### PR TITLE
Prevent challenges from being replayed

### DIFF
--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -249,6 +249,14 @@ pj_status_t user_lookup(pj_pool_t *pool,
     av = NULL;                                                 // LCOV_EXCL_LINE
   }
 
+  if ((av != NULL) &&
+       av->HasMember("tombstone"))
+  {
+    // av should be ignored as it has already been used
+    TRC_WARNING("Received an authentication request for %s with nonce %s, but matching AV has already been used - possible replay attack", impi.c_str(), nonce.c_str());
+    av = NULL;
+  }
+
   if (av != NULL)
   {
     pj_cstr(&cred_info->scheme, "digest");


### PR DESCRIPTION
Fixes the issue whereby nonces that have already been used to authenticate are not immediately deleted (they are lazily deleted via a "tombstone" record).

Tested using a SIPP script that fired in the same challenged REGISTER twice in succession (with the same nonce)

-  Without the fix, the second REGISTER succeeded
-  With the fix, the second REGISTER failed

Confirms that the fix prevents reply of REGISTERs (containing nonces that have already been used).

Fix does not need to be checked into CCv9/PC as the new nonce count PRD fixes the problem in a different way.