### PR TITLE
[Reviewer: Steve] Add CC specific file to gather diags folder

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-diags-monitor/scripts/sprout_cc_diags
+++ b/sprout-base.root/usr/share/clearwater/clearwater-diags-monitor/scripts/sprout_cc_diags
@@ -1,0 +1,37 @@
+# @file sprout_cc_diags
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2013  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script is executed in the context of the clearwater_diags_monitor script
+# (in the clearwater-infrastructure project).
+copy_to_dump '/var/lib/cc-ovf/'


### PR DESCRIPTION
Hi Steve, 

This is a fix to add CC specific diags to our collection script, under [this sfr](http://sfr/prodAsp/scripts/MSG/Issue.asp?issue_id=451953).

At the minute it's just a partial fix for a couple of reasons:

1. Doing it this way will mean a `*_cc_diags` file for each node type, probably with the same contents. This feels a bit ugly, but i can't think of a neater way.
2. I'm not sure which other diags files we might want. 

That said, this worked nicely when put onto `l3-cc4-sprout1`, and avoids having to modify any PC code.

If you're happy with 1. above, than I'll add a similar script to gather `/var/lib/cc-ovf/` on the other node types. Are there any other files that you think would be useful?