### PR TITLE
Handle digests and keys with null bytes in them

### DIFF
--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -305,7 +305,7 @@ pj_status_t user_lookup(pj_pool_t *pool,
       }
 
       cred_info->data_type = PJSIP_CRED_DATA_PLAIN_PASSWD;
-      pj_strdup2(pool, &cred_info->data, xres.c_str());
+      pj_strdup4(pool, &cred_info->data, xres.data(), xres.length());
       TRC_DEBUG("Found AKA XRES = %.*s", cred_info->data.slen, cred_info->data.ptr);
 
       // Use default realm as it isn't specified in the AV.

--- a/src/ut/authentication_test.cpp
+++ b/src/ut/authentication_test.cpp
@@ -206,6 +206,8 @@ class AuthenticationTest : public BaseAuthenticationTest
     ASSERT_EQ(PJ_SUCCESS, ret);
   }
 
+  void TestAKAAuthSuccess(char* key);
+
   static void TearDownTestCase()
   {
     destroy_authentication();
@@ -1304,20 +1306,10 @@ TEST_F(AuthenticationTest, DigestChallengeExpired)
   _hss_connection->delete_result("/impi/6505550001%40homedomain/av?impu=sip%3A6505550001%40homedomain");
 }
 
-TEST_F(AuthenticationTest, AKAAuthSuccess)
+void AuthenticationTest::TestAKAAuthSuccess(char* key)
 {
   // Test a successful AKA authentication flow.
   pjsip_tx_data* tdata;
-
-  // Set up the HSS response for the AV query using a default private user identity.
-  // The keys in this test case are not consistent, but that won't matter for
-  // the purposes of the test as Clearwater never itself runs the MILENAGE
-  // algorithms to generate or extract keys.
-  _hss_connection->set_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain",
-                              "{\"aka\":{\"challenge\":\"87654321876543218765432187654321\","
-                              "\"response\":\"12345678123456781234567812345678\","
-                              "\"cryptkey\":\"0123456789abcdef\","
-                              "\"integritykey\":\"fedcba9876543210\"}}");
 
   // Send in a REGISTER request with an authentication header with
   // integrity-protected=no.  This triggers aka authentication.
@@ -1345,7 +1337,7 @@ TEST_F(AuthenticationTest, AKAAuthSuccess)
   // response.
   AuthenticationMessage msg2("REGISTER");
   msg2._algorithm = "AKAv1-MD5";
-  msg2._key = "12345678123456781234567812345678";
+  msg2._key = key;
   msg2._nonce = auth_params["nonce"];
   msg2._opaque = auth_params["opaque"];
   msg2._nc = "00000001";
@@ -1360,6 +1352,36 @@ TEST_F(AuthenticationTest, AKAAuthSuccess)
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_AUTHENTICATION_STATS_TABLES.ims_aka_auth_tbl)->_successes);
 
   _hss_connection->delete_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain");
+}
+
+TEST_F(AuthenticationTest, AKAAuthSuccess)
+{
+  // Set up the HSS response for the AV query using a default private user identity.
+  // The keys in this test case are not consistent, but that won't matter for
+  // the purposes of the test as Clearwater never itself runs the MILENAGE
+  // algorithms to generate or extract keys.
+  _hss_connection->set_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain",
+                              "{\"aka\":{\"challenge\":\"87654321876543218765432187654321\","
+                              "\"response\":\"12345678123456781234567812345678\","
+                              "\"cryptkey\":\"0123456789abcdef\","
+                              "\"integritykey\":\"fedcba9876543210\"}}");
+
+  AuthenticationTest::TestAKAAuthSuccess("12345678123456781234567812345678");
+}
+
+TEST_F(AuthenticationTest, AKAAuthSuccessWithNullBytes)
+{
+  // Set up the HSS response for the AV query using a default private user identity.
+  // The keys in this test case are not consistent, but that won't matter for
+  // the purposes of the test as Clearwater never itself runs the MILENAGE
+  // algorithms to generate or extract keys.
+  _hss_connection->set_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain",
+                              "{\"aka\":{\"challenge\":\"87654321876543218765432187654321\","
+                              "\"response\":\"12345678000000000000000012345678\","
+                              "\"cryptkey\":\"0123456789abcdef\","
+                              "\"integritykey\":\"fedcba9876543210\"}}");
+
+  AuthenticationTest::TestAKAAuthSuccess("12345678000000000000000012345678");
 }
 
 TEST_F(AuthenticationTest, NoAlgorithmAKAAuthSuccess)


### PR DESCRIPTION
Use the known string length, rather than just up until the first null byte.