### PR TITLE
Generate SIP Call ID markers from In-Reply-To headers

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -68,6 +68,7 @@ const pj_str_t STR_P_PREFERRED_IDENTITY = pj_str((char*)"P-Preferred-Identity");
 const pj_str_t STR_P_ASSOCIATED_URI = pj_str((char*)"P-Associated-URI");
 const pj_str_t STR_REQUEST_DISPOSITION = pj_str((char*)"Request-Disposition");
 const pj_str_t STR_SERVICE_ROUTE = pj_str((char*)"Service-Route");
+const pj_str_t STR_IN_REPLY_TO = pj_str((char*)"In-Reply-To");
 const pj_str_t STR_ORIG = pj_str((char*)"orig");
 const pj_str_t STR_ORIG_CDIV = pj_str((char*)"orig-cdiv");
 const pj_str_t STR_NO_FORK = pj_str((char*)"no-fork");

--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -239,7 +239,7 @@ void create_random_token(size_t length, std::string& token);
 
 std::string get_header_value(pjsip_hdr*);
 
-void mark_sas_call_branch_ids(const SAS::TrailId trail, const std::vector<std::string>& cids, pjsip_msg* msg);
+void mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_msg* msg, const std::vector<std::string>& cids = std::vector<std::string>());
 
 bool is_emergency_registration(pjsip_contact_hdr* contact_hdr);
 

--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -239,7 +239,7 @@ void create_random_token(size_t length, std::string& token);
 
 std::string get_header_value(pjsip_hdr*);
 
-void mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* cid_hdr, pjsip_msg* msg);
+void mark_sas_call_branch_ids(const SAS::TrailId trail, const std::vector<std::string>& cids, pjsip_msg* msg);
 
 bool is_emergency_registration(pjsip_contact_hdr* contact_hdr);
 

--- a/src/common_sip_processing.cpp
+++ b/src/common_sip_processing.cpp
@@ -280,7 +280,7 @@ static void sas_log_rx_msg(pjsip_rx_data* rdata)
       }
     }
 
-    PJUtils::mark_sas_call_branch_ids(trail, call_ids, rdata->msg_info.msg);
+    PJUtils::mark_sas_call_branch_ids(trail, rdata->msg_info.msg, call_ids);
   }
 
   // Log the message event.
@@ -310,9 +310,7 @@ static void sas_log_tx_msg(pjsip_tx_data *tdata)
     if (tdata->msg->type == PJSIP_REQUEST_MSG)
     {
       PJUtils::report_sas_to_from_markers(trail, tdata->msg);
-      std::vector<std::string> empty_vector;
-
-      PJUtils::mark_sas_call_branch_ids(trail, empty_vector, tdata->msg);
+      PJUtils::mark_sas_call_branch_ids(trail, tdata->msg);
     }
 
     // Log the message event.

--- a/src/common_sip_processing.cpp
+++ b/src/common_sip_processing.cpp
@@ -237,9 +237,50 @@ static void sas_log_rx_msg(pjsip_rx_data* rdata)
   {
     PJUtils::report_sas_to_from_markers(trail, rdata->msg_info.msg);
 
+    std::vector<std::string> call_ids;
+
     pjsip_cid_hdr* cid = (pjsip_cid_hdr*)rdata->msg_info.cid;
 
-    PJUtils::mark_sas_call_branch_ids(trail, cid, rdata->msg_info.msg);
+    if (cid != NULL)
+    {
+      call_ids.push_back(PJUtils::pj_str_to_string(&cid->id));
+    }
+
+    // If this is a SIP MESSAGE then also pull out any In-Reply-To
+    // headers in order to correlate this trail with the trails
+    // for the calls identified in those headers.
+    pjsip_method* method = &rdata->msg_info.msg->line.req.method;
+
+    if ((method->id == PJSIP_OTHER_METHOD) &&
+        (pj_strcmp2(&method->name, "MESSAGE") == 0))
+    {
+      TRC_DEBUG("MESSAGE method - pull out In-Reply-To headers");
+      pjsip_in_reply_to_hdr* inreplyto;
+
+      for (inreplyto = (pjsip_in_reply_to_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                                          &STR_IN_REPLY_TO,
+                                                                          NULL);
+           inreplyto != NULL;
+           inreplyto = (pjsip_in_reply_to_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                                          &STR_IN_REPLY_TO,
+                                                                          inreplyto->next))
+      {
+        TRC_DEBUG("Found In-Reply-To header %.*s", inreplyto->hvalue.slen, inreplyto->hvalue.ptr);
+
+        // Split the header value by commas. Each resulting value is a Call-ID.
+        std::vector<std::string> inreplyto_call_ids;
+        Utils::split_string(PJUtils::pj_str_to_string(&inreplyto->hvalue),
+                            ',',
+                            inreplyto_call_ids);
+
+        // Append to list of all Call-IDs found so far.
+        call_ids.insert(call_ids.end(),
+                        inreplyto_call_ids.begin(),
+                        inreplyto_call_ids.end());
+      }
+    }
+
+    PJUtils::mark_sas_call_branch_ids(trail, call_ids, rdata->msg_info.msg);
   }
 
   // Log the message event.
@@ -269,8 +310,9 @@ static void sas_log_tx_msg(pjsip_tx_data *tdata)
     if (tdata->msg->type == PJSIP_REQUEST_MSG)
     {
       PJUtils::report_sas_to_from_markers(trail, tdata->msg);
+      std::vector<std::string> empty_vector;
 
-      PJUtils::mark_sas_call_branch_ids(trail, NULL, tdata->msg);
+      PJUtils::mark_sas_call_branch_ids(trail, empty_vector, tdata->msg);
     }
 
     // Log the message event.

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1226,7 +1226,8 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
     set_trail(tsx, get_trail(tdata));
     if (log_sas_branch)
     {
-      PJUtils::mark_sas_call_branch_ids(get_trail(tdata), NULL, tdata->msg);
+      std::vector<std::string> empty_vector;
+      PJUtils::mark_sas_call_branch_ids(get_trail(tdata), empty_vector, tdata->msg);
     }
 
     // Set up the module data for the new transaction to reference
@@ -1662,8 +1663,9 @@ std::string PJUtils::get_header_value(pjsip_hdr* header)
   return std::string(buf2, len);
 }
 
-/// Add SAS markers for the specified call ID and branch IDs on the message (call ID may be omitted, but not message).
-void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* cid_hdr, pjsip_msg* msg)
+/// Add SAS markers for the specified call IDs and branch IDs on the message
+// (call IDs may be empty; msg must not be NULL).
+void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, const std::vector<std::string>& cids, pjsip_msg* msg)
 {
   // Decide whether this is a message where we want to correlate on Call-ID or branch ID
   //
@@ -1683,12 +1685,15 @@ void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* 
                                 ((msg->line.req.method.id == PJSIP_REGISTER_METHOD) ||
                                  (pjsip_method_cmp(&msg->line.req.method, pjsip_get_subscribe_method()) == 0) ||
                                  (pjsip_method_cmp(&msg->line.req.method, pjsip_get_notify_method()) == 0)));
-  
-  if (cid_hdr != NULL)
+
+  for (std::vector<std::string>::const_iterator it = cids.begin();
+       it != cids.end();
+       it++)
   {
-    TRC_DEBUG("Logging SAS Call-ID marker, Call-ID %.*s", cid_hdr->id.slen, cid_hdr->id.ptr);
+    std::string cid = *it;
+    TRC_DEBUG("Logging SAS Call-ID marker, Call-ID %s", cid.c_str());
     SAS::Marker cid_marker(trail, MARKER_ID_SIP_CALL_ID, 1u);
-    cid_marker.add_var_param(cid_hdr->id.slen, cid_hdr->id.ptr);
+    cid_marker.add_var_param(cid.size(), (char*)cid.c_str());
     SAS::report_marker(cid_marker, branch_id_correlation ? SAS::Marker::Scope::None : SAS::Marker::Scope::Trace);
   }
 

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1226,8 +1226,7 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
     set_trail(tsx, get_trail(tdata));
     if (log_sas_branch)
     {
-      std::vector<std::string> empty_vector;
-      PJUtils::mark_sas_call_branch_ids(get_trail(tdata), empty_vector, tdata->msg);
+      PJUtils::mark_sas_call_branch_ids(get_trail(tdata), tdata->msg);
     }
 
     // Set up the module data for the new transaction to reference
@@ -1663,9 +1662,8 @@ std::string PJUtils::get_header_value(pjsip_hdr* header)
   return std::string(buf2, len);
 }
 
-/// Add SAS markers for the specified call IDs and branch IDs on the message
-// (call IDs may be empty; msg must not be NULL).
-void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, const std::vector<std::string>& cids, pjsip_msg* msg)
+/// Add SAS markers for the specified call IDs and branch IDs on the message (msg must not be NULL).
+void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_msg* msg, const std::vector<std::string>& cids)
 {
   // Decide whether this is a message where we want to correlate on Call-ID or branch ID
   //


### PR DESCRIPTION
Pulls out In-Reply-To headers on received MESSAGE, erm, messages. 

Tested using a modified version of the live test "Filtering - Accept-Contact", also passes a make full_test.