### PR TITLE
Improve Monit polling behavior during monitored process restart

### DIFF
--- a/sprout-base.root/usr/share/clearwater/bin/poll_sprout_http.sh
+++ b/sprout-base.root/usr/share/clearwater/bin/poll_sprout_http.sh
@@ -36,13 +36,23 @@
 
 scscf=5054
 . /etc/clearwater/config
+rc=0
 
 # If we have S-CSCF configured, check it.
-rc=0
 if [ "$scscf" != "0" ] ; then
   http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
   /usr/share/clearwater/bin/poll-http $http_ip:9888
   rc=$?
+fi
+
+# If the sprout process is not stable, we ignore a non-zero return code and
+# return zero.
+if [ $rc != 0 ]; then
+  /usr/share/clearwater/infrastructure/monit_stability/sprout-stability check
+  if [ $? != 0 ]; then
+    echo "return code $rc ignored" >&2
+    rc=0
+  fi
 fi
 
 exit $rc

--- a/sprout-base.root/usr/share/clearwater/bin/poll_sprout_sip.sh
+++ b/sprout-base.root/usr/share/clearwater/bin/poll_sprout_sip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# @file poll_sprout.sh
+# @file poll_sprout_sip.sh
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2014  Metaswitch Networks Ltd
@@ -54,6 +54,16 @@ fi
 if [ $rc = 0 ] && [ "$icscf" != "0" ] ; then
   $namespace_prefix /usr/share/clearwater/bin/poll-sip $icscf
   rc=$?
+fi
+
+# If the sprout process is not stable, we ignore a non-zero return code and
+# return zero.
+if [ $rc != 0 ]; then
+  /usr/share/clearwater/infrastructure/monit_stability/sprout-stability check
+  if [ $? != 0 ]; then
+    echo "return code $rc ignored" >&2
+    rc=0
+  fi
 fi
 
 exit $rc

--- a/sprout-base.root/usr/share/clearwater/infrastructure/monit_stability/sprout-stability
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/monit_stability/sprout-stability
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# @file sprout-stability
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# Used for monitoring the stability of the sprout process.
+
+PROCESS_NAME="sprout"
+GRACE_PERIOD=20
+
+method=$1
+
+/usr/share/clearwater/bin/process-stability $method $PROCESS_NAME $GRACE_PERIOD
+exit $?

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
@@ -49,7 +49,7 @@ check process sprout_process with pidfile /var/run/sprout/sprout.pid
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 80% then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/sprout-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
+  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/sprout-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program sprout_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-sprout-uptime

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
@@ -43,13 +43,13 @@ check process sprout_process with pidfile /var/run/sprout/sprout.pid
   group sprout
 
   # The start, stop and restart commands are linked to alarms
-  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout start'"
+  start program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/sprout-stability reset; /usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout start'"
   stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout stop'"
-  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout restart'"
+  restart program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/sprout-stability reset; /usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout restart'"
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
+  if memory > 80% then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/sprout-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program sprout_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-sprout-uptime
@@ -65,14 +65,14 @@ check program poll_sprout_sip with path "/usr/share/clearwater/bin/poll_sprout_s
   depends on sprout_process
 
   # Aborting generates a core file and triggers diagnostic collection.
-  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
+  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/sprout-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
 
 check program poll_sprout_http with path "/usr/share/clearwater/bin/poll_sprout_http.sh"
   group sprout
   depends on sprout_process
 
   # Aborting generates a core file and triggers diagnostic collection.
-  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
+  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/sprout-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
 EOF
 chmod 0644 /etc/monit/conf.d/sprout.monit
 


### PR DESCRIPTION
This is a process-specific fix for [#59](https://github.com/ClearwaterCore/clearwater-infrastructure/pull/59).