### PR TITLE
Backapplied memory leak & threading priority fixes

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -1,4 +1,6 @@
-#! /bin/sh
+#! /bin/bash
+# Use bash as the interpreter as we need more ulimit options than the default
+# shell provides.
 
 # @file sprout.init.d
 #
@@ -85,7 +87,7 @@ setup_environment()
         ulimit -Hn 1000000
         ulimit -Sn 1000000
         ulimit -c unlimited
-        ulimit -e 30 # Allow sprout threads to de-nice as far as -10.
+        ulimit -r 1 # Allow sprout threads to use realtime priorities.
         # enable gdb to dump a parent sprout process's stack
         echo 0 > /proc/sys/kernel/yama/ptrace_scope
 }

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -85,6 +85,7 @@ setup_environment()
         ulimit -Hn 1000000
         ulimit -Sn 1000000
         ulimit -c unlimited
+        ulimit -e 30 # Allow sprout threads to de-nice as far as -10.
         # enable gdb to dump a parent sprout process's stack
         echo 0 > /proc/sys/kernel/yama/ptrace_scope
 }

--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -1073,7 +1073,15 @@ void BasicProxy::UASTsx::on_new_client_response(UACTsx* uac_tsx,
 
       // Forward response with the UAS transaction
       on_tx_response(tdata);
-      pjsip_tsx_send_msg(_tsx, tdata);
+      pj_status_t status = pjsip_tsx_send_msg(_tsx, tdata);
+      if (status != PJ_SUCCESS)
+      {
+        // LCOV_EXCL_START
+        TRC_INFO("Failed to forward 1xx response: %s",
+                 PJUtils::pj_status_to_string(status).c_str());
+        pjsip_tx_data_dec_ref(tdata);
+        // LCOV_EXCL_STOP
+      }
     }
     else if (PJSIP_IS_STATUS_IN_CLASS(status_code, 200))
     {
@@ -1235,7 +1243,15 @@ void BasicProxy::UASTsx::on_final_response()
     set_trail(rsp, trail());
     pjsip_tx_data_invalidate_msg(rsp);
     on_tx_response(rsp);
-    pjsip_tsx_send_msg(_tsx, rsp);
+    pj_status_t status = pjsip_tsx_send_msg(_tsx, rsp);
+    if (status != PJ_SUCCESS)
+    {
+      // LCOV_EXCL_START
+      TRC_INFO("Failed to send final response: %s",
+               PJUtils::pj_status_to_string(status).c_str());
+      pjsip_tx_data_dec_ref(rsp);
+      // LCOV_EXCL_STOP
+    }
 
     if ((_tsx->method.id == PJSIP_INVITE_METHOD) &&
         (st_code == 200))
@@ -1270,7 +1286,18 @@ void BasicProxy::UASTsx::send_response(int st_code, const pj_str_t* st_text)
       {
         set_trail(prov_rsp, trail());
         on_tx_response(prov_rsp);
-        pjsip_tsx_send_msg(_tsx, prov_rsp);
+        pj_status_t status = pjsip_tsx_send_msg(_tsx, prov_rsp);
+        if (status != PJ_SUCCESS)
+        {
+          // LCOV_EXCL_START
+          TRC_INFO("Failed to send provisional response: %s",
+                   PJUtils::pj_status_to_string(status).c_str());
+
+          // pjsip_tsx_send_msg doesn't decrease the ref count on the tdata on
+          // failure
+          pjsip_tx_data_dec_ref(prov_rsp);
+          // LCOV_EXCL_STOP
+        }
       }
     }
     else if (_final_rsp != NULL)
@@ -1590,10 +1617,8 @@ BasicProxy::UACTsx::~UACTsx()
 
   if (_tdata != NULL)
   {
-    //LCOV_EXCL_START
     pjsip_tx_data_dec_ref(_tdata);
     _tdata = NULL;
-    //LCOV_EXCL_STOP
   }
 
   if ((_tsx != NULL) &&
@@ -1733,8 +1758,22 @@ void BasicProxy::UACTsx::send_request()
       {
         start_timer_c();
       }
+      else if (status != PJ_SUCCESS)
+      {
+        // LCOV_EXCL_START
+        TRC_INFO("Failed to send stateful request: %s",
+                 PJUtils::pj_status_to_string(status).c_str());
 
-      // We do not want to take any action on a failure returned from
+        // If we failed to send the message, the ref count on _tdata will not
+        // have been decreased, and we will have triggered a call into
+        // on_tsx_state already.
+        // That will have decided to retry the request if appropriate, and
+        // increased the ref count on _tdata so we should decrease it here.
+        pjsip_tx_data_dec_ref(_tdata);
+        // LCOV_EXCL_STOP
+      }
+
+      // We do not want to take any other actions on a failure returned from
       // pjsip_tsx_send_msg, as it will have also triggered a call into
       // on_tsx_state. In the event of failure, this will, or already has
       // cause us to call into retry_request; we do not want to call into
@@ -1833,6 +1872,12 @@ void BasicProxy::UACTsx::cancel_pending_tsx(int st_code, const std::string& reas
 
           // Send the CANCEL on the new transaction.
           status = pjsip_tsx_send_msg(_cancel_tsx, cancel);
+          if (status != PJ_SUCCESS)
+          {
+            //LCOV_EXCL_START
+            pjsip_tx_data_dec_ref(cancel);
+            //LCOV_EXCL_STOP
+          }
         }
 
         if (status != PJ_SUCCESS)

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1103,6 +1103,9 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
 
             // We no longer care about the old tdata.
             pjsip_tx_data_dec_ref(old_tdata);
+            old_tdata = nullptr;
+
+            sss->tdata = tdata;
           }
           // LCOV_EXCL_STOP
 
@@ -1136,7 +1139,17 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
             // the send - it will always call on_tsx_state on success or
             // failure, and that will recover.
             PJUtils::set_dest_info(tdata, sss->servers[sss->current_server]);
-            (void)pjsip_tsx_send_msg(retry_tsx, tdata);
+            pj_status_t tsx_status = pjsip_tsx_send_msg(retry_tsx, tdata);
+
+            if (tsx_status != PJ_SUCCESS)
+            {
+              TRC_DEBUG("Failed to to send retry: %s",
+                        PJUtils::pj_status_to_string(tsx_status).c_str());
+
+              // The same logic in send_request applies here too.
+              pjsip_tx_data_dec_ref(tdata);
+              tdata = nullptr;
+            }
           }
         }
       }
@@ -1159,6 +1172,7 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
     // The transaction has completed, so decrement our reference to the tx_data
     // and free the state data.
     pjsip_tx_data_dec_ref(sss->tdata);
+    sss->tdata = nullptr;
     delete sss;
   }
 }
@@ -1239,12 +1253,39 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
 
     if (status != PJ_SUCCESS)
     {
-      // If pjsip_tsx_send_msg fails when the UAC transaction is in NULL
-      // state it will always call the on_tsx_state callback terminating
-      // the transaction, so no clean-up left to do, and must return
-      // PJ_SUCCESS to caller to avoid potential double-free errors.  It's
-      // also not safe to access the request here, and logging of the error
-      // will have happened in the callback.
+      TRC_DEBUG("Failed to to send retry: '%s' for %p",
+                PJUtils::pj_status_to_string(status).c_str());
+
+      // Note, on_tsx_state callback is called irrespective of whether
+      // tsx_send_msg fails. on_tsx_state will also be called if tsx_send_msg
+      // succeeds, but the message actually fails to be sent. Note also that
+      // on_tsx_state can not differentiate between these two cases.
+
+      // There are three different memory controls we need to worry about here
+      // - (1) The reference to the tx_data in Stateful Send State added above
+      //   and (2) the pjsip_transaction object, which contains a reference to the
+      //   tx_data.
+      //
+      //   These will be tidied up by the on_tsx_state callback, so we don't need
+      //   to remove those reference here. This will happen in success and
+      //   failure of tsx_send_msg
+      //
+      // - (3) The reference owned by the caller which was passed into this
+      //   function by the caller.
+      //
+      //   In the success case, tsx_send_msg will decrement this reference. In
+      //   the failure case, it won't. Thus, given on_tsx_state will handle
+      //   further processing, and to keep the interface to this function clean,
+      //   we should decrement the reference here.
+      pjsip_tx_data_dec_ref(tdata);
+      tdata = nullptr;
+
+      // Also, in order to keep the interface clean, we should return
+      // PJ_SUCCESS here. This is the lesser of the two evils - returning an
+      // error would indicate that the message failed, even though the
+      // on_tsx_state callback may actually succeed a retry in the future.
+      // We should only return an error if there is no chance of this function
+      // succeeding.
       status = PJ_SUCCESS;
     }
   }
@@ -1263,6 +1304,7 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
     // Since the on_tsx_state callback will not have been called we must
     // clean up resources here.
     pjsip_tx_data_dec_ref(tdata);
+    tdata = nullptr;
     delete sss;
   }
 
@@ -1310,8 +1352,7 @@ static void stateless_send_cb(pjsip_send_state *st,
       // but just in case ...
       PJUtils::generate_new_branch_id(tdata);
 
-      // Add a reference to the tdata to stop PJSIP releasing it when we
-      // return the callback.
+      // Add a reference to the tdata to send a new request with
       pjsip_tx_data_add_ref(tdata);
 
       // Set up destination info for the new server and resend the request.
@@ -1323,11 +1364,14 @@ static void stateless_send_cb(pjsip_send_state *st,
 
       if (status == PJ_SUCCESS)
       {
+        // Reference has been taken by sending it
+        tdata = nullptr;
         retrying = true;
       }
       else
       {
         pjsip_tx_data_dec_ref(tdata);
+        tdata = nullptr;
       }
     }
   }
@@ -1390,6 +1434,7 @@ pj_status_t PJUtils::send_request_stateless(pjsip_tx_data* tdata, int retries)
               PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR,
                                      PJUtils::next_hop(tdata->msg)).c_str());
     pjsip_tx_data_dec_ref(tdata);
+    tdata = nullptr;
     delete sss;
   }
 
@@ -1437,6 +1482,7 @@ pj_status_t PJUtils::respond_stateless(pjsip_endpoint* endpt,
     if (tdata->msg->body == NULL)
     {
       pjsip_tx_data_dec_ref(tdata);
+      tdata = nullptr;
       return status;
     }
   }
@@ -1446,6 +1492,7 @@ pj_status_t PJUtils::respond_stateless(pjsip_endpoint* endpt,
   if (status != PJ_SUCCESS)
   {
     pjsip_tx_data_dec_ref(tdata);
+    tdata = nullptr;
     return status;
   }
 
@@ -1457,9 +1504,15 @@ pj_status_t PJUtils::respond_stateless(pjsip_endpoint* endpt,
 
   // Send!
   status = pjsip_endpt_send_response(endpt, &res_addr, tdata, NULL, NULL);
-  if (status != PJ_SUCCESS)
+  if (status == PJ_SUCCESS)
+  {
+    // Reference has been used by send_response
+    tdata = nullptr;
+  }
+  else
   {
     pjsip_tx_data_dec_ref(tdata);
+    tdata = nullptr;
     return status;
   }
 
@@ -1518,6 +1571,24 @@ pj_status_t PJUtils::respond_stateful(pjsip_endpoint* endpt,
   }
 
   status = pjsip_tsx_send_msg(uas_tsx, tdata);
+
+  if (status == PJ_SUCCESS)
+  {
+    // Reference has been taken by tsx_send_msg
+    tdata = nullptr;
+  }
+  else
+  {
+    // The message is owned by the transaction, which will get a on_tsx_state
+    // callback. However, we still have a reference count if tsx_send_msg
+    // fails, which we should decrement, to prevent a leak.
+    pjsip_tx_data_dec_ref(tdata);
+    tdata = nullptr;
+
+    // Even if we failed to send, we should treat it as a success, as the
+    // message may be resent by the transaction owner.
+    status = PJ_SUCCESS;
+  }
 
   return status;
 }

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -978,7 +978,15 @@ void SproutletProxy::UASTsx::tx_response(SproutletWrapper* downstream,
       int st_code = rsp->msg->line.status.code;
       set_trail(rsp, trail());
       on_tx_response(rsp);
-      pjsip_tsx_send_msg(_tsx, rsp);
+      pj_status_t status = pjsip_tsx_send_msg(_tsx, rsp);
+
+      if (status != PJ_SUCCESS)
+      {
+        TRC_INFO("Failed to send UASTsx message: %s",
+                 PJUtils::pj_status_to_string(status).c_str());
+        // pjsip_tsx_send_msg only decreases the ref count on success
+        pjsip_tx_data_dec_ref(rsp);
+      }
 
       if (st_code >= PJSIP_SC_OK)
       {

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -553,6 +553,17 @@ pj_status_t init_pjsip()
   status = pjsip_endpt_create(&stack_data.cp.factory, NULL, &stack_data.endpt);
   PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);
 
+  // Increase the limit on the number of timers that PJSIP processes each time
+  // it polls the timer heap.
+  //
+  // By default PJSIP will process up to 64 timers and 16 epoll events per call
+  // to pjsip_endpt_handle_events. This ratio means that if inbound messages
+  // spawn more than a handlful of timers we can set timers faster than they can
+  // be expired.
+  pj_timer_heap_set_max_timed_out_per_poll(
+                                   pjsip_endpt_get_timer_heap(stack_data.endpt),
+                                   4096);
+
   // Init transaction layer.
   status = pjsip_tsx_layer_init_module(stack_data.endpt);
   PJ_ASSERT_RETURN(status == PJ_SUCCESS, status);

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -48,6 +48,9 @@ extern "C" {
 
 #include <arpa/inet.h>
 
+#include <pthread.h>
+#include <sched.h>
+
 // Common STL includes.
 #include <cassert>
 #include <vector>
@@ -180,15 +183,20 @@ static int pjsip_thread_func(void *p)
 
   TRC_STATUS("PJSIP transport thread started with kernel thread ID %d", tid);
 
-  // Increase the priority of the transport thread (by reducing its niceness to
-  // -10). This means that the transport thread is scheduled more aggressively
-  // than the worker threads which means that messages are read from the network
-  // promptly, but then rejected due to unavailability of the worker threads.
-  if (setpriority(PRIO_PROCESS, 0, -10) != 0)
+  // Increase the priority of the transport thread (by giving it a real-time
+  // scheduling policy and a non-zero priority). This means that the transport
+  // thread is scheduled more aggressively than the worker threads which means
+  // that messages are read from the network promptly, but then rejected due to
+  // unavailability of the worker threads.
+  pthread_t this_thread = pthread_self();
+
+  struct sched_param params;
+  params.sched_priority = sched_get_priority_min(SCHED_FIFO);
+
+  if (pthread_setschedparam(this_thread, SCHED_FIFO, &params) != 0)
   {
-    TRC_WARNING("Unable to increase priority of the transport thread. "
-                "Overload may not be handled gracefully. "
-                "Error: %s", strerror(errno));
+    TRC_WARNING("Unable to set SCHED_FIFO scheduling policy on the transport thread. "
+                "Overload may not be handled gracefully");
   }
 
   pj_bool_t curr_quiescing = PJ_FALSE;

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -56,6 +56,9 @@ extern "C" {
 #include <list>
 #include <queue>
 #include <string>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
 
 #include "constants.h"
 #include "eventq.h"
@@ -170,7 +173,11 @@ static int pjsip_thread_func(void *p)
 
   PJ_UNUSED_ARG(p);
 
-  TRC_STATUS("PJSIP thread started");
+  // Get the Kernel's ID for this thread so we can log it out.
+  pid_t tid;
+  tid = syscall(SYS_gettid);
+
+  TRC_STATUS("PJSIP transport thread started with kernel thread ID %d", tid);
 
   pj_bool_t curr_quiescing = PJ_FALSE;
   pj_bool_t new_quiescing = quiescing;

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -59,6 +59,7 @@ extern "C" {
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/resource.h>
 
 #include "constants.h"
 #include "eventq.h"
@@ -178,6 +179,17 @@ static int pjsip_thread_func(void *p)
   tid = syscall(SYS_gettid);
 
   TRC_STATUS("PJSIP transport thread started with kernel thread ID %d", tid);
+
+  // Increase the priority of the transport thread (by reducing its niceness to
+  // -10). This means that the transport thread is scheduled more aggressively
+  // than the worker threads which means that messages are read from the network
+  // promptly, but then rejected due to unavailability of the worker threads.
+  if (setpriority(PRIO_PROCESS, 0, -10) != 0)
+  {
+    TRC_WARNING("Unable to increase priority of the transport thread. "
+                "Overload may not be handled gracefully. "
+                "Error: %s", strerror(errno));
+  }
 
   pj_bool_t curr_quiescing = PJ_FALSE;
   pj_bool_t new_quiescing = quiescing;


### PR DESCRIPTION
Hi Steve,

This PR backapplies the following fixes from dev to v10:

- Added a log displaying the ID the kernel has assigned to PJSIP transport thread (https://github.com/Metaswitch/sprout/commit/f5a6618a45eeb0baf7f999db15d5a5d09fb546f2)
- Increased rate of timer pops (https://github.com/Metaswitch/sprout/commit/0523f7f7d96e836dc590bdf61d30ee1813ffe665)
- Prioritise transport thread more aggressively than worker threads (https://github.com/Metaswitch/sprout/commit/00d83053b8d3918ea9d40ada4bc62612c0131026 and https://github.com/Metaswitch/sprout/commit/02eff6394ea8f462f00a857fbb06a25fa87df7b5 in that order!)
- Memory leak fixes (https://github.com/Metaswitch/sprout/pull/2001 and https://github.com/Metaswitch/sprout/pull/2082)

Testing: